### PR TITLE
default.json: don't pin docker digests

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
+      "config:recommended",
+      "helpers:pinGitHubActionDigests",
+      ":pinDevDependencies"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
@fmarier believes we should not pin docker digests,
so I'm moving from `best-practices` to `best-practices`-`docker:pinDigests`:

```
  'best-practices': {
    configMigration: true,
    description:
      'Preset with best practices from the Renovate maintainers. Recommended for advanced users, who want to follow our best practices.',
    extends: [
      'config:recommended',
      'docker:pinDigests',
      'helpers:pinGitHubActionDigests',
      ':pinDevDependencies',
    ],
  },
```