### PR TITLE
default.json: Enable all github-actions updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -14,6 +14,10 @@
     {
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "enabled": true
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
We are currently disabling all `major` updates, this PR re-enables them for Github Actions.