### PR TITLE
default.json: enable branchNameStrict

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,6 +5,7 @@
       "helpers:pinGitHubActionDigestsToSemver",
       ":pinDevDependencies"
   ],
+  "branchNameStrict": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "major", "patch", "pin", "pinDigest", "digest"],


### PR DESCRIPTION
@jonathansampson noted that some of the Renovate branch names (e.g. `esbuild<=0.24.2-0.x`) are invalid on Windows systems and therefore can cause `git pull` to fail.

```txt
error: cannot lock ref 'refs/remotes/origin/renovate/esbuild<=0.24.2-0.x': Unable to create 'C:/Brave/brave-com/.git/refs/remotes/origin/renovate/esbuild<=0.24.2-0.x.lock': Invalid argument
From https://github.com/brave/brave-com
 ! [new branch]          renovate/esbuild<=0.24.2-0.x -> origin/renovate/esbuild<=0.24.2-0.x  (unable to update local ref)
```

This PR aims to address the problem by enabling [`branchNameStrict`](https://docs.renovatebot.com/configuration-options/#branchnamestrict) which removes special characters from the branch name.