### PR TITLE
Fix github-actions matching

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,9 +18,10 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["patch", "minor", "pin", "pinDigest", "digest"],
-      "matchCurrentAge": "> 2 weeks",
-      "matchRepositories": ["actions/**", "github/**", "aws-actions/**"],
+      "matchUpdateTypes": ["patch", "minor", "pin", "pinDigest"],
+      "matchCurrentAge": "> 7 days",
+      "matchPackageNames": ["actions/**", "github/**", "aws-actions/**"],
+      "minimumReleaseAge": "14 days",
       "autoApprove": true,
       "automerge": true
     },


### PR DESCRIPTION
This PR fixes multiple issues with the GIthub Actions rule:
- `matchRepositories` matches the consumer repo rather than the dependency name
- `matchCurrentAge` matches the age of the currently installed package (to prevent update churn)
- `minimumReleaseAge` cooldown
