### PR TITLE
feat: enable gomodTidy in default preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,6 +6,7 @@
       ":pinDevDependencies"
   ],
   "branchNameStrict": true,
+  "postUpdateOptions": ["gomodTidyE"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "major", "patch", "pin", "pinDigest", "digest"],


### PR DESCRIPTION
This PR enables [Module Tidying](https://docs.renovatebot.com/golang/#module-tidying) (`go mod tidy`), the documented trade-off about unrelated changes being confusing seems acceptable.