### PR TITLE
Enable gomodTidyAll

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,7 +6,7 @@
       ":pinDevDependencies"
   ],
   "branchNameStrict": true,
-  "postUpdateOptions": ["gomodTidyE"],
+  "postUpdateOptions": ["gomodTidyAll"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "major", "patch", "pin", "pinDigest", "digest"],


### PR DESCRIPTION
> When a shared module is updated in a Go monorepo, go mod tidy currently runs only on the directly updated module.
> Dependent modules that reference it through a local replace directive (for example replace shared => ../shared) keep a stale go.sum, which breaks their build.
> 
> gomodTidyAll solves this by:
> 
> 1. Building a dependency graph from all go.mod files and their local replace directives
> 2. Finding all modules that transitively depend on the updated module
> 3. Appending a go mod tidy command for each dependent module, in topological order (dependencies before dependents)